### PR TITLE
update "DEFAULT" keyword for v2

### DIFF
--- a/src/components/Shades.vue
+++ b/src/components/Shades.vue
@@ -196,7 +196,7 @@ export default {
       if (!this.result.shades || !this.result.shades.length) {
         return {}
       }
-      let shades = [`  default: '#${this.result.shades[4].hex}'`]
+      let shades = [`  DEFAULT: '#${this.result.shades[4].hex}'`]
       for (let i in this.result.shades) {
         shades.push(`  '${parseInt(i) + 1}00': '#${this.result.shades[i].hex}'`)
       }


### PR DESCRIPTION
For Tailwind 2.0, we need to use "DEFAULT" instead of "default" to generate the correct class names.

https://tailwindcss.com/docs/upgrading-to-v2