### PR TITLE
changes to support customizing stops

### DIFF
--- a/src/components/Shades.vue
+++ b/src/components/Shades.vue
@@ -148,7 +148,7 @@ export default {
 
       shades.push(
         ...this.result.shades.map(({ stop, hex }) => {
-          return `  '${stop * 100}': '#${hex},'`
+          return `  '${stop * 100}': '#${hex}'`
         })
       )
 


### PR DESCRIPTION
Thanks for making this tool! I've found it really helpful ☺️

**📎 References Issue**
- https://github.com/anheric/tailwindshades/issues/6: Specify stops

**⚙️ Changes**
- Adds `stops` property to `Shades.vue` which takes in an Array of stops, for example:
```js
[0.5, 1, 1.5, 2, 3, 4, 5, 6, 7, 8, 9]
// creates color shades
// 50, 100, 150, 200, 300, 400, 500, 600, 700, 800, 900
````
- Update to computed function `result` which uses values in `stops` to calculate color shades.
```js
let shades = this.stops.map(stop => {
    let distance = 5 - stop
    let direction = distance > 0 ? stepUp : stepDown
    let lightness = this.clamp(hsl[2] + direction * distance, 0, 100)
    let hex = converter.rgb.hex(converter.hsl.rgb([hsl[0], hsl[1], lightness]))

    return {
        stop,
        hex,
        textColor: this.textColorFromBrightness(hex),
    }
})
```
- Updates references to base color as `this.result.color.hex`

**❇️ Why**
- Will be helpful when making a new UI element to allow users to define custom stops.

<img width="1792" alt="preview" src="https://user-images.githubusercontent.com/2532937/103959724-76dd1080-511e-11eb-99f1-3c98154d51bd.png">