### PR TITLE
Implement ability to choose base shade stop number

### DIFF
--- a/src/components/BaseSelect.vue
+++ b/src/components/BaseSelect.vue
@@ -27,15 +27,12 @@
             ></div>
           </div>
         </div>
-        <div class="mt-8">
-          <p class="text-left">Select which shade step you want the base color to apply at (default 500)</p>
-          <div class="flex mt-3">
-            <div v-for="stop in stops" :key="'stop-' + stop">
-              <input type="radio" v-model="baseShadeStop" name="baseShadeStop" :value="stop" class="ml-2" />
-              <label for="baseShadeStop" class="pl-2">{{ stop * 100 }}</label>
-            </div>
-          </div>
-        </div>
+        <BaseStopSelect
+          class="mt-8"
+          v-show="validHex"
+          :base-shade-stop="baseShadeStop"
+          @set-base-shade-stop="baseShadeStop = $event"
+        />
         <transition name="fade">
           <div
             class="btn mt-8 py-4 px-8"
@@ -149,6 +146,7 @@
         :dbShade="shade"
         :colors.sync="colors"
         :baseShadeStop="baseShadeStop"
+        @set-base-shade-stop="baseShadeStop = $event"
         ref="shadesComponent"
       />
     </div>
@@ -162,6 +160,7 @@ import CarbonAds from '@/components/CarbonAds'
 import converter from 'color-convert'
 import DropdownComponent from '@/components/Dropdown'
 import CommunityQuickSelect from '@/components/CommunityQuickSelect'
+import BaseStopSelect from '@/components/BaseStopSelect'
 
 export default {
   components: {
@@ -169,6 +168,7 @@ export default {
     CarbonAds,
     DropdownComponent,
     CommunityQuickSelect,
+    BaseStopSelect,
   },
   metaInfo: {
     title: 'Tailwind Shades',
@@ -199,7 +199,6 @@ export default {
       ],
       hasURLHash: window.location.hash.length > 2,
       shadeHasUnsavedChanges: false,
-      stops: [0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9],
       baseShadeStop: 5,
     }
   },

--- a/src/components/BaseSelect.vue
+++ b/src/components/BaseSelect.vue
@@ -27,6 +27,15 @@
             ></div>
           </div>
         </div>
+        <div class="mt-8">
+          <p class="text-left">Select which shade step you want the base color to apply at (default 500)</p>
+          <div class="flex mt-3">
+            <div v-for="stop in stops" :key="'stop-' + stop">
+              <input type="radio" v-model="baseShadeStop" name="baseShadeStop" :value="stop" class="ml-2" />
+              <label for="baseShadeStop" class="pl-2">{{ stop * 100 }}</label>
+            </div>
+          </div>
+        </div>
         <transition name="fade">
           <div
             class="btn mt-8 py-4 px-8"
@@ -139,10 +148,10 @@
         :initialHEX="hex"
         :dbShade="shade"
         :colors.sync="colors"
+        :baseShadeStop="baseShadeStop"
         ref="shadesComponent"
       />
     </div>
-
   </div>
 </template>
 
@@ -190,6 +199,8 @@ export default {
       ],
       hasURLHash: window.location.hash.length > 2,
       shadeHasUnsavedChanges: false,
+      stops: [0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+      baseShadeStop: 5,
     }
   },
   computed: {
@@ -213,7 +224,7 @@ export default {
     const shade = this.$route.params.shade
     if (shade) {
       this.shade = shade
-      this.hex = shade.colors[5]
+      this.hex = shade.colors[this.baseShadeStop]
       this.step = 'shades'
     }
 

--- a/src/components/BaseStopSelect.vue
+++ b/src/components/BaseStopSelect.vue
@@ -1,0 +1,40 @@
+<template>
+  <div class="mt-8">
+    <p
+      class="text-left"
+      :class="{'text-sm': small }"
+    >{{ title }}</p>
+    <div
+      class="flex"
+      :class="small ? 'mt-1' : 'mt-2'"
+    >
+      <div
+        v-for="stop in stops"
+        :key="'base-stop-' + stop"
+        class="flex-grow bg-theme-600 py-2 cursor-pointer select-none text-sm text-center"
+        :class="{ 'bg-theme-800': baseShadeStop === stop } "
+        @click="$emit('set-base-shade-stop', stop)"
+      >
+        {{ stop * 100 }}
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    title: {
+      type: String,
+      default: 'Move base stop (default 500)',
+    },
+    baseShadeStop: Number,
+    small: Boolean,
+  },
+  data() {
+    return {
+      stops: [0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+    }
+  },
+}
+</script>

--- a/src/components/Shades.vue
+++ b/src/components/Shades.vue
@@ -170,7 +170,15 @@
                     />
                   </div>
                 </div>
+
               </div>
+              <BaseStopSelect
+                class="mt-2"
+                :base-shade-stop="baseShadeStop"
+                title="Move base stop"
+                :small="true"
+                @set-base-shade-stop="$emit('set-base-shade-stop', $event)"
+              />
             </div>
           </div>
 
@@ -223,16 +231,17 @@
             <div class="mb-2">
               <div class="flex items-center leading-none border-b border-theme-600">
                 <p class="text-xl font-black mr-3 border-r border-theme-600 w-10 h-10 flex items-center justify-center">3</p>
-                <p class="text-xl py-2 px-2 text-theme-darker font-bold">Get code</p>
+                <p class="text-xl py-2 px-2 text-theme-darker font-bold w-1/3">Get code</p>
+                <div class="px-4 flex-grow">
+                  <input
+                    class="form-control"
+                    type="text"
+                    v-model="code.name"
+                  />
+                </div>
               </div>
             </div>
             <div class="px-2 relative">
-              <label class="text-sm font-bold">Color name:</label>
-              <input
-                class="form-control"
-                type="text"
-                v-model="code.name"
-              />
               <prism-component language="javascript">{{ code.name | appendColon }}{{ codeDisplay }}</prism-component>
               <input
                 type="hidden"
@@ -257,6 +266,7 @@
 import converter from 'color-convert'
 import { ntc } from '@/lib/ntc.js'
 import SliderInput from '@/components/SliderInput'
+import BaseStopSelect from '@/components/BaseStopSelect'
 import PrismComponent from 'vue-prism-component'
 import _ from 'lodash'
 
@@ -270,6 +280,7 @@ export default {
   components: {
     SliderInput,
     PrismComponent,
+    BaseStopSelect,
   },
   data() {
     return {
@@ -484,6 +495,7 @@ export default {
         'step-down': this.groupOptions.stepDown,
         'hue-shift': this.groupOptions.hueShift,
         name: this.code.name,
+        'base-stop': this.baseShadeStop,
       }
 
       let defaultOverridable = this.defaultOverridable()
@@ -559,6 +571,17 @@ export default {
       let namePattern = new RegExp(/[A-z /]+$/i)
       if (!namePattern.test(name)) {
         return false
+      }
+
+      lookup = parts.find(p => p[0] === 'base-step')
+      if (lookup?.length) {
+        let baseStep = lookup[1]
+        if (this.stops.includes(baseStep)) {
+          this.$emit('set-base-shade-stop', baseStep)
+        }
+      } else {
+        // for backwards-compatible URLs.
+        this.$emit('set-base-shade-stop', 5)
       }
 
       let urlOverridesRaw = parts.find(p => p[0] === 'overrides')

--- a/src/components/Shades.vue
+++ b/src/components/Shades.vue
@@ -40,9 +40,9 @@
               class="border-l border-r border-theme-600"
               :class="[
                 'flex flex-grow',
-                { 'font-black': stop === 5 },
-                { 'border-t': stops[0] === stop},
-                { 'border-b': stops[stops.length - 1] === stop}
+                { 'font-black': stop === baseShadeStop },
+                { 'border-t': stops[0] === stop },
+                { 'border-b': stops[stops.length - 1] === stop },
               ]"
               :style="`background-color: #${(override ? override.hex : hex)}; color: ${(override ? override.textColor : textColor)};`"
             >
@@ -264,6 +264,7 @@ export default {
   props: {
     initialHEX: String,
     colors: Array,
+    baseShadeStop: Number,
     dbShade: {},
   },
   components: {
@@ -338,9 +339,10 @@ export default {
       let stepUp = this.groupOptions.stepUp
       let stepDown = this.groupOptions.stepDown
       let rgb = converter.hsl.rgb(hsl)
+      let baseShadeStop = this.baseShadeStop
 
       let shades = this.stops.map(stop => {
-        const distance = 5 - stop
+        const distance = baseShadeStop - stop
         let direction = distance > 0 ? stepUp : stepDown
         let lightness = this.clamp(hsl[2] + direction * distance, 0, 100)
 
@@ -435,16 +437,16 @@ export default {
     },
     // auto is not used currently.
     auto() {
-      const baseShade = this.result.shades[5]
+      const baseShade = this.result.shades[this.baseShadeStop]
 
       for (let i in this.result.shades) {
         let currentShade = this.result.shades[i]
-        if (currentShade.stop == 5) {
+        if (currentShade.stop == this.baseShadeStop) {
           continue
         }
 
         i = parseInt(i)
-        let scale = Math.abs(i - 5)
+        let scale = Math.abs(i - this.baseShadeStop)
 
         // Looping HSL values here [h, s, l].
         for (let j = 0; j <= 2; j++) {


### PR DESCRIPTION
closes #22 

Hello! I really like this tool / website for programmatic color palette generation, but I was also having issues similar to #22 so  I forked the repo so I could hack a solution since I was kind of blocked on a product I'm working on. 

Note I don't know Vue.js, so feel free to tear this PR apart if there's bad Vue hacking going on 😅  

Also the new UI is super basic but here it is:

### Choosing the base shade of the color hex

![Screen Shot 2022-04-26 at 4 37 01 PM](https://user-images.githubusercontent.com/13444851/165390719-4a0f379f-6fb7-46b4-a32a-27c1c1d99246.png)

### Default shade results

Note how the selected base shade is bolded.

<img width="1472" alt="Screen Shot 2022-04-26 at 4 37 18 PM" src="https://user-images.githubusercontent.com/13444851/165390817-0d45208c-a44f-4e23-959f-0956a32c3ab3.png">


I'll also leave some comments in-line!

